### PR TITLE
Improved Search Feature in MaweJS Editor

### DIFF
--- a/src/gui/editor/editor.js
+++ b/src/gui/editor/editor.js
@@ -499,44 +499,18 @@ class ChooseRightPanel extends React.PureComponent {
   }
 */
 
-// class Searching extends React.PureComponent {
-
-//   render() {
-//     const {editor, searchText, setSearchText, searchBoxRef} = this.props
-
-//     if(typeof(searchText) !== "string") return <Button
-//       tooltip="Search text"
-//       size="small"
-//     >
-//       <Icon.Action.Search onClick={ev => setSearchText("")}/>
-//     </Button>
-
-//     return <SearchBox
-//       inputRef={searchBoxRef}
-//       size="small"
-//       //defaultValue={searchText}
-//       value={searchText}
-//       autoFocus
-//       onChange={ev => setSearchText(ev.target.value)}
-//       onBlur={ev => {if(!searchText) setSearchText(undefined)}}
-//       onKeyDown={ev => {
-//         if(IsKey.Enter(ev)) {
-//           ev.preventDefault();
-//           ev.stopPropagation();
-//           if(searchText === "") setSearchText(undefined)
-//           searchFirst(editor, searchText, true)
-//         }
-//       }}
-//     />
-//   }
-// }
-
 class Searching extends React.PureComponent {
+  // Simulates pressing ESC key
+  handleEscBehavior = () => {
+    // Call the method that you would normally call when ESC is pressed
+    this.props.setSearchText(undefined);
+  }
+
   /**
    * Clears the current search text.
    */
   clearSearch = () => {
-    this.props.setSearchText("");
+    this.handleEscBehavior();
   }
 
   /**
@@ -555,6 +529,19 @@ class Searching extends React.PureComponent {
 
   render() {
     const { editor, searchText, setSearchText, searchBoxRef } = this.props;
+
+    // Define inline styles for icon-like buttons
+    const iconButtonStyle = {
+      background: 'none',
+      border: 'none',
+      cursor: 'pointer',
+      padding: '0',
+      margin: '0 5px',
+      fontSize: '16px',
+      color: '#333',
+      outline: 'none',
+    };
+
 
     // Render a search icon button if no search text is defined.
     if (typeof(searchText) !== "string") {
@@ -588,13 +575,15 @@ class Searching extends React.PureComponent {
             }
           }}
         />
-        <button onClick={this.clearSearch}>X</button>
-        <button onClick={this.searchPrevious}>↑</button>
-        <button onClick={this.searchNext}>↓</button>
-      </div>
+        <button style={iconButtonStyle} onClick={this.clearSearch} title="Clear search">✖️</button> {}
+        <button style={iconButtonStyle} onClick={this.searchPrevious} title="Previous search result">↑</button> {}
+        <button style={iconButtonStyle} onClick={this.searchNext} title="Next search result">↓</button> {}
+       </div>
     );
   }
 }
+
+
 
 
 //-----------------------------------------------------------------------------

--- a/src/gui/editor/editor.js
+++ b/src/gui/editor/editor.js
@@ -499,37 +499,103 @@ class ChooseRightPanel extends React.PureComponent {
   }
 */
 
+// class Searching extends React.PureComponent {
+
+//   render() {
+//     const {editor, searchText, setSearchText, searchBoxRef} = this.props
+
+//     if(typeof(searchText) !== "string") return <Button
+//       tooltip="Search text"
+//       size="small"
+//     >
+//       <Icon.Action.Search onClick={ev => setSearchText("")}/>
+//     </Button>
+
+//     return <SearchBox
+//       inputRef={searchBoxRef}
+//       size="small"
+//       //defaultValue={searchText}
+//       value={searchText}
+//       autoFocus
+//       onChange={ev => setSearchText(ev.target.value)}
+//       onBlur={ev => {if(!searchText) setSearchText(undefined)}}
+//       onKeyDown={ev => {
+//         if(IsKey.Enter(ev)) {
+//           ev.preventDefault();
+//           ev.stopPropagation();
+//           if(searchText === "") setSearchText(undefined)
+//           searchFirst(editor, searchText, true)
+//         }
+//       }}
+//     />
+//   }
+// }
+
 class Searching extends React.PureComponent {
+  /**
+   * Clears the current search text.
+   */
+  clearSearch = () => {
+    this.props.setSearchText("");
+  }
+
+  /**
+   * Navigates to the next search result.
+   */
+  searchNext = () => {
+    searchForward(this.props.editor, this.props.searchText, true);
+  }
+
+  /**
+   * Navigates to the previous search result.
+   */
+  searchPrevious = () => {
+    searchBackward(this.props.editor, this.props.searchText, true);
+  }
 
   render() {
-    const {editor, searchText, setSearchText, searchBoxRef} = this.props
+    const { editor, searchText, setSearchText, searchBoxRef } = this.props;
 
-    if(typeof(searchText) !== "string") return <Button
-      tooltip="Search text"
-      size="small"
-    >
-      <Icon.Action.Search onClick={ev => setSearchText("")}/>
-    </Button>
+    // Render a search icon button if no search text is defined.
+    if (typeof(searchText) !== "string") {
+      return (
+        <Button
+          tooltip="Search text"
+          size="small"
+        >
+          <Icon.Action.Search onClick={ev => setSearchText("")}/>
+        </Button>
+      );
+    }
 
-    return <SearchBox
-      inputRef={searchBoxRef}
-      size="small"
-      //defaultValue={searchText}
-      value={searchText}
-      autoFocus
-      onChange={ev => setSearchText(ev.target.value)}
-      onBlur={ev => {if(!searchText) setSearchText(undefined)}}
-      onKeyDown={ev => {
-        if(IsKey.Enter(ev)) {
-          ev.preventDefault();
-          ev.stopPropagation();
-          if(searchText === "") setSearchText(undefined)
-          searchFirst(editor, searchText, true)
-        }
-      }}
-    />
+    // Render the search box with additional controls for clearing the search text,
+    // and navigating through search results.
+    return (
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <SearchBox
+          inputRef={searchBoxRef}
+          size="small"
+          value={searchText}
+          autoFocus
+          onChange={ev => setSearchText(ev.target.value)}
+          onBlur={ev => { if (!searchText) setSearchText(undefined) }}
+          onKeyDown={ev => {
+            if (IsKey.Enter(ev)) {
+              ev.preventDefault();
+              ev.stopPropagation();
+              if (searchText === "") setSearchText(undefined);
+              searchFirst(editor, searchText, true);
+            }
+          }}
+        />
+        <button onClick={this.clearSearch}>X</button>
+        <button onClick={this.searchPrevious}>↑</button>
+        <button onClick={this.searchNext}>↓</button>
+      </div>
+    );
   }
 }
+
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
## What's New
I made the search tool in MaweJS editor better and solving [issue 162](https://github.com/mkoskim/mawejs/issues/162). Now, it's easier to use, especially for people who like using the mouse. I kept the keyboard shortcuts the same, so they still work like before.

## What I Did
- **Clear Button**: Added a new button to erase the search text quickly. This makes it easier to stop searching with just one click.
- **Next and Previous Buttons**: Put in two new buttons to go to the next or previous search results easily. This is great for people who prefer using the mouse.

## Why It Matters
These changes make searching in the editor nicer and easier for everyone. Whether you like using the keyboard or the mouse, you can search easily. I checked everything to make sure it all works well.

## Extra Info
I made sure that my changes fit well with the way MaweJS is already built. I also wrote documentation in the code so others can understand what I did.

I'd love to hear any thoughts or ideas to make it even better!
