### PR TITLE
Exclude folded blocks when searching

### DIFF
--- a/src/gui/editor/slateEditor.js
+++ b/src/gui/editor/slateEditor.js
@@ -462,6 +462,24 @@ function withIDs(editor) {
 
 //*****************************************************************************
 //
+// With Word Count
+//
+//*****************************************************************************
+
+function withWordCount(editor) {
+  const { normalizeNode } = editor;
+
+  editor.normalizeNode = (entry)=> {
+    const [node, path] = entry
+
+    return normalizeNode(entry);
+  }
+
+  return editor;
+}
+
+//*****************************************************************************
+//
 // Folding
 //
 //*****************************************************************************

--- a/src/gui/editor/slateHelpers.js
+++ b/src/gui/editor/slateHelpers.js
@@ -52,6 +52,18 @@ function elemIsType(editor, elem, type) {
 }
 
 //-----------------------------------------------------------------------------
+// Check, if element is inside folded block
+
+function elemIsFolded(editor, path) {
+  for(const np of Node.levels(editor, path)) {
+    const [node, path] = np
+    //console.log("Node:", node);
+    if(node.folded) return true;
+  }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
 
 // Return true, if editor operations change content
 // Return false, if operations only change selection
@@ -266,9 +278,10 @@ function searchTextForward(editor, text, path, offset) {
   if(match) return match
 
   const next = Editor.next(editor, {
-    match: (n, p) => !Path.equals(path, p) && Text.isText(n) && searchOffsets(n.text, re).length
+    match: (n, p) => !Path.equals(path, p) && !elemIsFolded(editor, p) && Text.isText(n) && searchOffsets(n.text, re).length
   })
   if(!next) return undefined
+
   //console.log(next)
   return searchMatchNext(re, next[0], next[1])
 }
@@ -281,7 +294,7 @@ function searchTextBackward(editor, text, path, offset) {
   if(match) return match
 
   const prev = Editor.previous(editor, {
-    match: (n, p) => !Path.equals(path, p) && Text.isText(n) && searchOffsets(n.text, re).length
+    match: (n, p) => !Path.equals(path, p) && !elemIsFolded(editor, p) && Text.isText(n) && searchOffsets(n.text, re).length
   })
   if(!prev) return undefined
   //console.log(next)


### PR DESCRIPTION
Do not search inside folded blocks. The other possibility would be automatically unfold the block, if search goes inside one.
