### PR TITLE
Clean up unnecessary useState()'s

### DIFF
--- a/examples/StyleTest.mawe
+++ b/examples/StyleTest.mawe
@@ -41,4 +41,14 @@ NOTES
 </scene>
 </part>
 </notes>
+<!--/
+===============================================================================
+/-->
+<ui>
+<view/>
+<chart elements="scenes" template="plotpoints" mode="topCCW"/>
+<editor>
+<body words="numbers" indexed="part,scene,synopsis"/>
+</editor>
+</ui>
 </story>

--- a/src/gui/app/settings.js
+++ b/src/gui/app/settings.js
@@ -39,7 +39,11 @@ export function useSetting(key, defaultValue) {
   return [value, setValue];
 }
 
-//-----------------------------------------------------------------------------
+//*****************************************************************************
+//
+// Recent file list in Local Storage
+//
+//*****************************************************************************
 
 export function recentAdd(file, recent, setRecent) {
   setRecent([
@@ -53,12 +57,3 @@ export function recentRemove(file, recent, setRecent) {
     ...recent.filter(entry => entry.id !== file.id)
   ])
 }
-
-/*
-export function getStartupCommand(loaded) {
-
-  if(loaded) return { action: "load", filename: loaded }
-
-  return { action: "set", buffer: '<story format="mawe" />' }
-}
-*/

--- a/src/gui/app/views.js
+++ b/src/gui/app/views.js
@@ -1,13 +1,13 @@
 //*****************************************************************************
 //*****************************************************************************
 //
-// Edit view selection
+// View selection
 //
 //*****************************************************************************
 //*****************************************************************************
 
 import React, {
-  useState, useCallback,
+  useCallback,
 } from "react"
 
 import {
@@ -19,14 +19,15 @@ import { Organizer } from "../organizer/organizer";
 import { Chart } from "../chart/chart"
 import { Export } from "../export/export"
 
-//-----------------------------------------------------------------------------
-// Chart settings
-//-----------------------------------------------------------------------------
+//*****************************************************************************
+//
+// View settings
+//
+//*****************************************************************************
 
 export function loadViewSettings(settings) {
   return {
     selected: "editor",
-    focusTo: undefined,
     ...(settings?.attributes ?? {})
   }
 }
@@ -42,15 +43,11 @@ export function saveViewSettings(settings) {
 export function getViewMode(doc) { return doc.ui.view.selected; }
 export function setViewMode(updateDoc, value) { updateDoc(doc => {doc.ui.view.selected = value})}
 
-export function getFocusTo(doc) { return doc.ui.view.focusTo; }
-export function setFocusTo(updateDoc, value) {
-  updateDoc(doc => {
-    doc.ui.view.selected = "editor"
-    doc.ui.view.focusTo = value
-  })
-}
-
-//-----------------------------------------------------------------------------
+//*****************************************************************************
+//
+// View selection
+//
+//*****************************************************************************
 
 export class ViewSelectButtons extends React.PureComponent {
 

--- a/src/gui/chart/chart.js
+++ b/src/gui/chart/chart.js
@@ -7,7 +7,6 @@
 //*****************************************************************************
 
 import React, {
-  useState,
   useCallback,
 } from "react"
 
@@ -112,6 +111,16 @@ function IndexToolbar({ }) {
 //
 //*****************************************************************************
 
+function mode2rotate(mode) {
+  switch (mode) {
+    case "topCCW":    return { start:  90, rotate:  1}
+    case "topCW":     return { start:  90, rotate: -1}
+    case "bottomCCW": return { start: 270, rotate:  1}
+    case "bottomCW":  return { start: 270, rotate: -1}
+  }
+  return { start: 0, rotate: 1 }
+}
+
 function ChartView({doc, updateDoc}) {
 
   const section = doc.body
@@ -120,11 +129,9 @@ function ChartView({doc, updateDoc}) {
   // Data selection
   //---------------------------------------------------------------------------
 
-  //const [selectElement, setSelectElement] = useState("scenes")
-  //const [selectTemplate, setSelectTemplate] = useState("plotpoints")
-
   const setElements = useCallback(value => updateDoc(doc => {doc.ui.chart.elements = value}), [updateDoc])
   const setTemplate = useCallback(value => updateDoc(doc => {doc.ui.chart.template = value}), [updateDoc])
+  const setMode     = useCallback((mode) => {updateDoc(doc => {doc.ui.chart.mode = mode})}, [updateDoc])
 
   /*
   console.log("Beat sheet length=", tmplButtons.beatsheet.data
@@ -137,24 +144,7 @@ function ChartView({doc, updateDoc}) {
   // Chart directions
   //---------------------------------------------------------------------------
 
-  //const [mode, _setMode] = useState("topCCW")
-  const [selectStart, setSelectStart] = useState(90)
-  const [selectRotate, setSelectRotate] = useState(1)
-
-  const setMode = useCallback((mode) => {
-    updateDoc(doc => doc.ui.chart.mode = mode)
-    switch (mode) {
-      case "topCCW": return setStartRotate(90, 1)
-      case "topCW": return setStartRotate(90, -1)
-      case "bottomCCW": return setStartRotate(270, 1)
-      case "bottomCW": return setStartRotate(270, -1)
-    }
-
-    function setStartRotate(start, rotate) {
-      setSelectStart(start)
-      setSelectRotate(rotate)
-    }
-  }, [updateDoc])
+  const {start: selectStart, rotate: selectRotate} = mode2rotate(doc.ui.chart.mode)
 
   //---------------------------------------------------------------------------
   // View

--- a/src/gui/common/components.js
+++ b/src/gui/common/components.js
@@ -7,30 +7,19 @@
 //*****************************************************************************
 
 import React, {
-  useState, useEffect, useReducer,
-  useMemo, useCallback,
-  useDeferredValue,
-  StrictMode,
-  useContext,
 } from 'react';
 
 import {
-  FlexBox, VBox, HBox, Filler, VFiller, HFiller,
-  ToolBox, Button, Icon, Tooltip,
-  ToggleButton, ToggleButtonGroup, MakeToggleGroup,
-  TextField, Input,
-  SearchBox,
+  VBox,
+  Button, Icon,
+  MakeToggleGroup,
+  TextField,
   Label,
-  List, ListItem, ListItemText,
-  Grid,
-  Separator, Loading, addClass,
-  Menu, MenuItem,
   Accordion, AccordionSummary, AccordionDetails,
 } from "../common/factory";
 
 import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
 
-import { produce } from 'immer';
 import { mawe } from "../../document"
 import {cmdOpenFolder} from '../app/context';
 import {Popover} from '@mui/material';

--- a/src/gui/editor/editor.js
+++ b/src/gui/editor/editor.js
@@ -659,15 +659,15 @@ function EditorBox({style, settings, mode="Condensed"}) {
   }[active]
 
   return <VFiller>
+    {/* Editor toolbar */}
+
     <ToolBox style={doc.ui.editor.toolbox.mid}>
-      {/* <EditHeadButton head={head} updateDoc={settings.updateDoc} expanded={true}/> */}
       <Searching editor={activeEditor} searchText={searchText} setSearchText={setSearchText} searchBoxRef={searchBoxRef}/>
       <Filler />
-      {/* <OpenFolderButton filename={doc.file?.id}/> */}
-      {/* <Separator/> */}
-      {/* <SectionWordInfo section={doc.body}/> */}
     </ToolBox>
+
     {/* Editor board and sheet */}
+
     <div className="Filler Board" style={{...style}}>
       <Slate editor={settings.body.editor} initialValue={settings.body.buffer} onChange={settings.body.onChange}>
       {

--- a/src/gui/editor/editor.js
+++ b/src/gui/editor/editor.js
@@ -241,8 +241,8 @@ export function SingleEditView({doc, updateDoc}) {
 
   const setSearchText = useCallback(text => {
     _setSearchText(text)
-    searchFirst(getEditorBySectID(active), text)
-  }, [getEditorBySectID, active])
+    searchFirst(getActiveEdit(), text)
+  }, [getActiveEdit])
 
   //---------------------------------------------------------------------------
   // Render elements: what we want is to get menu items from subcomponents to

--- a/src/gui/editor/slateEditor.js
+++ b/src/gui/editor/slateEditor.js
@@ -6,21 +6,21 @@
 //*****************************************************************************
 //*****************************************************************************
 
-import React, { useState, useEffect, useMemo, useCallback, useDeferredValue } from 'react';
-import { useSlate, Editable, withReact, ReactEditor } from 'slate-react'
+import React, { useMemo, useCallback } from 'react';
+import { useSlate, Editable, withReact } from 'slate-react'
 import {
   Editor,
   Node, Text,
   Transforms,
-  Range, Point, Path,
+  Range, Point,
   createEditor,
   Element,
 } from 'slate'
 
 import { withHistory } from "slate-history"
-import { addClass, IsKey, Icon } from '../common/factory';
+import { addClass, IsKey } from '../common/factory';
 import { nanoid } from '../../util';
-import {elemAsText, section2lookup, wcElem, wcCompare, filterCtrlElems} from '../../document/util';
+import { wcElem, wcCompare} from '../../document/util';
 
 import {
   text2Regexp, searchOffsets, searchPattern,

--- a/src/gui/editor/slateHelpers.js
+++ b/src/gui/editor/slateHelpers.js
@@ -428,19 +428,19 @@ function searchTextBackward(editor, text, path, offset) {
 // Search with scrolling and optional focusing
 
 export function searchFirst(editor, text, doFocus=false) {
-  const {path, offset} = editor.selection.focus
+  const {path, offset} = editor.selection?.focus ?? Editor.start(editor, [])
 
   return searchWithScroll(editor, text, path, offset, true, doFocus)
 }
 
 export function searchForward(editor, text, doFocus=false) {
-  const {path, offset} = editor.selection.focus
+  const {path, offset} = editor.selection?.focus ?? Editor.start(editor, [])
 
   return searchWithScroll(editor, text, path, offset+1, true, doFocus)
 }
 
 export function searchBackward(editor, text, doFocus=false) {
-  const {path, offset} = editor.selection.focus
+  const {path, offset} = editor.selection?.focus ?? Editor.start(editor, [])
 
   return searchWithScroll(editor, text, path, offset, false, doFocus)
 }

--- a/src/gui/editor/tagTable.js
+++ b/src/gui/editor/tagTable.js
@@ -7,25 +7,12 @@
 //*****************************************************************************
 
 import React, {
-  useState, useEffect, useReducer,
-  useMemo, useCallback,
-  useDeferredValue,
-  StrictMode,
-  useRef,
+  useCallback,
 } from 'react';
 
 import {
-  FlexBox, VBox, HBox, Filler, VFiller, HFiller,
-  ToolBox, Button, Icon, Tooltip,
-  ToggleButton, ToggleButtonGroup, MakeToggleGroup,
-  Input,
-  SearchBox,
+  VBox, HBox,
   Label,
-  List, ListItem, ListItemText,
-  Grid,
-  Separator, Loading, addClass,
-  Menu, MenuItem,
-  isHotkey,
 } from "../common/factory";
 
 import {createTagTable} from "../../document/util";

--- a/src/gui/export/export.js
+++ b/src/gui/export/export.js
@@ -8,10 +8,8 @@ import "./styles/export.css"
 import "../common/styles/sheet.css"
 
 import React, {
-  useState, useEffect, useReducer,
   useMemo, useCallback,
   useDeferredValue,
-  StrictMode,
 } from 'react';
 
 import {
@@ -46,7 +44,7 @@ import { formatRTF } from "./formatRTF";
 import { formatHTML } from "./formatHTML"
 import { formatTXT } from "./formatTXT"
 import { formatTEX1, formatTEX2 } from "./formatTEX"
-import { setFocusTo } from "../app/views";
+import { setFocusTo } from "../editor/editor";
 
 //-----------------------------------------------------------------------------
 
@@ -183,33 +181,33 @@ function ExportIndex({ style, doc, updateDoc }) {
   const { parts } = doc.body
 
   return <VFiller className="TOC" style={style}>
-    {filterCtrlElems(parts).map(part => <PartItem key={part.id} part={part} updateDoc={updateDoc}/>)}
+    {filterCtrlElems(parts).map(part => <PartItem key={part.id} part={part} doc={doc} updateDoc={updateDoc}/>)}
   </VFiller>
 }
 
-function PartItem({ part, updateDoc }) {
+function PartItem({ part, doc, updateDoc }) {
   const { id, children } = part
   const name = elemName(part)
   return <>
     <div
       className="Entry PartName"
       onClick={ev => window.location.href = `#${id}`}
-      onDoubleClick={ev => setFocusTo(updateDoc, { id })}
+      onDoubleClick={ev => setFocusTo(updateDoc, "body", id)}
       style={{ cursor: "pointer" }}
     >
       <span className="Name">{name}</span>
     </div>
-    {filterCtrlElems(children).map(scene => <SceneItem key={scene.id} scene={scene} updateDoc={updateDoc}/>)}
+    {filterCtrlElems(children).map(scene => <SceneItem key={scene.id} scene={scene} doc={doc} updateDoc={updateDoc}/>)}
   </>
 }
 
-function SceneItem({ scene, updateDoc }) {
+function SceneItem({ scene, doc, updateDoc }) {
   const { id } = scene
   const name = elemName(scene)
   return <div
     className="Entry SceneName"
     onClick={ev => window.location.href = `#${id}`}
-    onDoubleClick={ev => setFocusTo(updateDoc, { id })}
+    onDoubleClick={ev => setFocusTo(updateDoc, "body", id)}
     style={{ cursor: "pointer" }}
   >
     <span className="Name">{name}</span>

--- a/src/gui/organizer/organizer.js
+++ b/src/gui/organizer/organizer.js
@@ -97,7 +97,6 @@ function OrganizerView({doc, updateDoc}) {
       total: body.words.text + body.words.missing,
       cumulative: wcCumulative(body)
     },
-    //focusTo: id => setFocusTo({sectID: "body", id}),
   }
 
   const note_settings = {
@@ -107,7 +106,6 @@ function OrganizerView({doc, updateDoc}) {
     words: {
       value: "off",
     },
-    //focusTo: id => setFocusTo({sectID: "notes", id}),
   }
 
   return <div className="Filler Organizer" style={{overflow: "auto"}}>

--- a/src/gui/workspace/workspace.js
+++ b/src/gui/workspace/workspace.js
@@ -11,7 +11,7 @@
 import "./workspace.css"
 
 import React from "react";
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useSelector, useDispatch } from "react-redux";
 import {action, docByID } from "../app/store"
 


### PR DESCRIPTION
When we have moved settings to doc object, there is not that much need for all sorts of useState()'s. Doc object can hold settings for UI.

Resolves #201 

Also, improves editor focusing:

Resolves #91 
