### PR TITLE
Initially focus editor

### DIFF
--- a/src/gui/editor/editor.js
+++ b/src/gui/editor/editor.js
@@ -254,6 +254,11 @@ export function SingleEditView({doc, updateDoc}) {
     }
   }, [focusTo, getActiveEdit])
 
+  // Initially focus editor
+  useEffect(() => {
+    ReactEditor.focus(getActiveEdit())
+  })
+
   //---------------------------------------------------------------------------
   // Search
   //---------------------------------------------------------------------------


### PR DESCRIPTION
When rendering editor view, initially focus editor component.

Resolves #210 
