### PR TITLE
Import view

### DIFF
--- a/src/document/xmljs/load.js
+++ b/src/document/xmljs/load.js
@@ -36,11 +36,18 @@ import { createDateStamp } from "../util";
 //const convert = require('xml-js');
 
 export async function loadmawe(file) {
-  return createmawe(await file2buf(file))
+  return maweFromBuffer(await file2buf(file))
 }
 
 export function createmawe(buffer) {
-  const tree = buf2tree(buffer)
+  return maweFromBuffer(buffer)
+}
+
+export function maweFromBuffer(buffer) {
+  return maweFromTree(buf2tree(buffer))
+}
+
+export function maweFromTree(tree) {
   const story = fromXML(tree)
   //console.log("Story:", story)
   return {

--- a/src/gui/app/app.js
+++ b/src/gui/app/app.js
@@ -113,10 +113,7 @@ export default function App(props) {
     /*/
     setCommand({
       action: "import",
-      file: {
-        id: "./examples/Frankenstein.txt",
-        name: "Frankenstein.txt",
-      },
+      file: {id: "./examples/Frankenstein.txt", name: "Frankenstein.txt" },
       ext: ".txt",
     })
     /**/

--- a/src/gui/app/app.js
+++ b/src/gui/app/app.js
@@ -42,7 +42,8 @@ import {
   cmdLoadFile,
   cmdNewFile, cmdOpenFile, cmdOpenFolder, cmdOpenHelp,
   cmdOpenImportFile, cmdImportFile,
-  cmdSaveFile, cmdSaveFileAs
+  cmdSaveFile, cmdSaveFileAs,
+  cmdImportClipboard
 } from "./context"
 
 import {
@@ -93,6 +94,7 @@ export default function App(props) {
     switch(action) {
       case "load": { docFromFile(command); break; }
       case "import": { importFromFile(command); break; }
+      case "clipboard": { importFromClipboard(command); break; }
       case "save": { docSave(command); break; }
       case "set": { docFromBuffer(command); break; }
       case "resource": { docFromResource(command); break; }
@@ -107,7 +109,7 @@ export default function App(props) {
   //---------------------------------------------------------------------------
 
   useEffect(() => {
-    /*
+    //*
     //console.log("Recent:", recent)
     if(recent?.length) cmdLoadFile({setCommand, filename: recent[0].id})
     /*/
@@ -156,6 +158,17 @@ export default function App(props) {
     })
     .catch(err => {
       Inform.error(err);
+    })
+  }
+
+  function importFromClipboard() {
+    navigator.clipboard.readText()
+    .then(content => {
+      setBuffer({file: undefined, ext: ".txt", content})
+      //Inform.success(`Loaded: ${file.name}`);
+    })
+    .catch(err => {
+      //Inform.error(err);
     })
   }
 
@@ -240,17 +253,10 @@ function WorkspaceTab({doc, updateDoc, buffer, setBuffer}) {
   ]));
 
   //console.log("Recent:", recent)
-  if(buffer) return <WithBuffer setCommand={setCommand} recent={recent} buffer={buffer} setBuffer={setBuffer}/>
+  //if(buffer) return <WithBuffer setCommand={setCommand} recent={recent} buffer={buffer} setBuffer={setBuffer}/>
+  if(buffer) return null
   if(!doc) return <WithoutDoc setCommand={setCommand} recent={recent}/>
   return <WithDoc setCommand={setCommand} recent={recent} doc={doc} updateDoc={updateDoc}/>
-}
-
-function WithBuffer({buffer, setBuffer}) {
-  return <ToolBox>
-    <Label>Import: {buffer.file.name}</Label>
-    <IconButton onClick={e => setBuffer(undefined)}><Icon.Close/></IconButton>
-    <Separator/>
-  </ToolBox>
 }
 
 function WithoutDoc({setCommand, recent}) {
@@ -325,6 +331,9 @@ class FileMenu extends React.PureComponent {
           <Separator/>
           <MenuItem onClick={e => { cmdOpenImportFile({setCommand, file}); popupState.close(e); }}>
             <ListItemText>Import file...</ListItemText>
+            </MenuItem>
+          <MenuItem onClick={e => { cmdImportClipboard({setCommand}); popupState.close(e); }}>
+            <ListItemText>Import clipboard</ListItemText>
             </MenuItem>
           <Separator/>
           <MenuItem disabled={!file} onClick={e => { cmdSaveFile({setCommand, file}); popupState.close(e); }}>

--- a/src/gui/app/app.js
+++ b/src/gui/app/app.js
@@ -131,10 +131,10 @@ export default function App(props) {
     })
   }
 
-  function importFromFile({file}) {
+  function importFromFile({file, ext}) {
     fs.read(file.id)
     .then(content => {
-      setBuffer({file, content})
+      setBuffer({file, ext, content})
       Inform.success(`Loaded: ${file.name}`);
     })
     .catch(err => {

--- a/src/gui/app/app.js
+++ b/src/gui/app/app.js
@@ -85,6 +85,7 @@ export default function App(props) {
   const [buffer, setBuffer] = useState()
 
   //console.log("Doc:", doc)
+  console.log("Command:", command)
 
   useEffect(() => {
     if(!command) return
@@ -101,10 +102,29 @@ export default function App(props) {
     }
   }, [command])
 
+  //---------------------------------------------------------------------------
+  // Startup command
+  //---------------------------------------------------------------------------
+
   useEffect(() => {
+    /*
     //console.log("Recent:", recent)
     if(recent?.length) cmdLoadFile({setCommand, filename: recent[0].id})
+    /*/
+    setCommand({
+      action: "import",
+      file: {
+        id: "./examples/Frankenstein.txt",
+        name: "Frankenstein.txt",
+      },
+      ext: ".txt",
+    })
+    /**/
   }, [])
+
+  //---------------------------------------------------------------------------
+  // Render
+  //---------------------------------------------------------------------------
 
   return <ThemeProvider theme={theme}>
     <SnackbarProvider>

--- a/src/gui/app/context.js
+++ b/src/gui/app/context.js
@@ -74,6 +74,11 @@ export async function cmdOpenFile({ setCommand, file }) {
 
 //-----------------------------------------------------------------------------
 
+export function cmdImportClipboard({setCommand}) {
+  console.log("Import clipboard")
+  setCommand({action: "clipboard"})
+}
+
 export function cmdImportFile({setCommand, file, ext}) {
   console.log("Import file:", file.name)
   setCommand({action: "import", file, ext})

--- a/src/gui/app/context.js
+++ b/src/gui/app/context.js
@@ -74,9 +74,9 @@ export async function cmdOpenFile({ setCommand, file }) {
 
 //-----------------------------------------------------------------------------
 
-export function cmdImportFile({setCommand, file}) {
+export function cmdImportFile({setCommand, file, ext}) {
   console.log("Import file:", file.name)
-  setCommand({action: "import", file})
+  setCommand({action: "import", file, ext})
 }
 
 export async function cmdOpenImportFile({setCommand, file}) {
@@ -88,7 +88,9 @@ export async function cmdOpenImportFile({setCommand, file}) {
   })
   if (!canceled) {
     const [filename] = filePaths
-    cmdImportFile({setCommand, file: await fs.fstat(filename)})
+    const file = await fs.fstat(filename)
+    const ext  = await fs.extname(file.id)
+    cmdImportFile({setCommand, file, ext})
   }
 }
 

--- a/src/gui/app/context.js
+++ b/src/gui/app/context.js
@@ -21,10 +21,19 @@ export const CmdContext = createContext(null)
 
 const fs = require("../../system/localfs")
 
+//-----------------------------------------------------------------------------
+
 const filters = [
   { name: 'Mawe Files', extensions: ['moe', 'mawe', 'mawe.gz'] },
   { name: 'All Files', extensions: ['*'] }
 ]
+
+const importFilters = [
+  { name: 'Text files', extensions: ['txt', 'md'] },
+  { name: 'All Files', extensions: ['*'] }
+]
+
+//-----------------------------------------------------------------------------
 
 export async function cmdOpenFolder(file) {
   const dirname = file ? await fs.dirname(file) : "."
@@ -43,6 +52,8 @@ export async function cmdNewFile({ setCommand }) {
   })
 }
 
+//-----------------------------------------------------------------------------
+
 export function cmdLoadFile({setCommand, filename}) {
   console.log("Load file:", filename)
   setCommand({action: "load", filename})
@@ -60,6 +71,28 @@ export async function cmdOpenFile({ setCommand, file }) {
     cmdLoadFile({setCommand, filename})
   }
 }
+
+//-----------------------------------------------------------------------------
+
+export function cmdImportFile({setCommand, file}) {
+  console.log("Import file:", file.name)
+  setCommand({action: "import", file})
+}
+
+export async function cmdOpenImportFile({setCommand, file}) {
+  const { canceled, filePaths } = await fileOpenDialog({
+    title: "Import File",
+    filters: importFilters,
+    defaultPath: file?.id ?? ".",
+    properties: ["OpenFile"],
+  })
+  if (!canceled) {
+    const [filename] = filePaths
+    cmdImportFile({setCommand, file: await fs.fstat(filename)})
+  }
+}
+
+//-----------------------------------------------------------------------------
 
 export async function cmdSaveFile({ setCommand, file }) {
   if (file) {

--- a/src/gui/app/views.js
+++ b/src/gui/app/views.js
@@ -18,6 +18,7 @@ import { SingleEditView } from "../editor/editor";
 import { Chart } from "../chart/chart"
 import { Stats } from "../stats/stats"
 import { Export } from "../export/export"
+import {ImportView} from "../import/import";
 
 //*****************************************************************************
 //
@@ -73,7 +74,11 @@ export class ViewSelectButtons extends React.PureComponent {
   }
 }
 
-export function ViewSwitch({doc, updateDoc}) {
+export function ViewSwitch({doc, updateDoc, buffer, setBuffer}) {
+
+  if(buffer) {
+    return <ImportView doc={doc} updateDoc={updateDoc} buffer={buffer} setBuffer={setBuffer}/>
+  }
 
   if(!doc) return null
 

--- a/src/gui/editor/slateEditor.js
+++ b/src/gui/editor/slateEditor.js
@@ -38,6 +38,7 @@ import {
   Menu, MenuItem, ListItemIcon, Typography,
 } from '../common/factory';
 import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
+import { text2lines } from '../import/import';
 
 export {
   text2Regexp,
@@ -582,11 +583,7 @@ function withTextPaste(editor) {
 
     //console.log(text)
 
-    const [first, ...lines] = text
-      .replaceAll("\r", "")
-      .split(/\n+/)
-      .map(line => line.trim())
-    ;
+    const [first, ...lines] = text2lines(text);
 
     //*
     editor.insertText(first)

--- a/src/gui/export/export.js
+++ b/src/gui/export/export.js
@@ -97,15 +97,11 @@ export function Export({ doc, updateDoc }) {
   const format = doc.exports.format
   const setFormat = useCallback(value => updateDoc(doc => { doc.exports.format = value}), [])
 
-  return <VBox style={{ overflow: "auto" }}>
-    {/* <ExportToolbar {...previewprops}/> */}
-    <HBox style={{ overflow: "auto" }}>
-      {/* <ExportSettings {...previewprops}/> */}
-      <ExportIndex style={{ maxWidth: "300px", width: "300px" }} doc={doc} updateDoc={updateDoc}/>
-      <Preview doc={doc}/>
-      <ExportSettings doc={doc} updateDoc={updateDoc} format={format} setFormat={setFormat}/>
-    </HBox>
-  </VBox>
+  return <HBox style={{ overflow: "auto" }}>
+    <ExportIndex style={{ maxWidth: "300px", width: "300px" }} doc={doc} updateDoc={updateDoc}/>
+    <Preview doc={doc}/>
+    <ExportSettings doc={doc} updateDoc={updateDoc} format={format} setFormat={setFormat}/>
+  </HBox>
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gui/export/styles/export.css
+++ b/src/gui/export/styles/export.css
@@ -1,5 +1,5 @@
 .ExportSettings {
   background: white;
   padding: 6px;
-  border-right: 1px solid lightgray;
+  border-left: 1px solid lightgray;
 }

--- a/src/gui/import/import.js
+++ b/src/gui/import/import.js
@@ -6,7 +6,7 @@
 //*****************************************************************************
 //*****************************************************************************
 
-//import "./styles/export.css"
+import "./styles/import.css"
 import "../common/styles/sheet.css"
 
 import React, {
@@ -16,27 +16,26 @@ import React, {
 
 import {
   FlexBox, VBox, HBox, Filler, VFiller, HFiller,
-  ToolBox, Button, Icon, Tooltip,
+  ToolBox, Button, Icon, Tooltip, IconButton,
   ToggleButton, ToggleButtonGroup,
   Radio,
   Input,
-  SearchBox,
   Label,
   List, ListItem, ListItemText, ListSubheader,
   Grid,
   Separator, Loading, addClass,
   TextField, SelectFrom,
-  MenuItem,
+  Menu, MenuItem,
   Accordion, AccordionSummary, AccordionDetails,
   DeferredRender,
   Inform,
 } from "../common/factory";
 
+import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
+
 import { elemName, getSuffix, nanoid, filterCtrlElems } from "../../document/util";
-import {
-  EditHead, SectionWordInfo,
-  updateDocStoryType, updateDocChapterElem, updateDocChapterType,
-} from "../common/components";
+import { Preview } from "./preview";
+import { maweFromTree } from "../../document/xmljs/load";
 
 //*****************************************************************************
 //
@@ -44,15 +43,123 @@ import {
 //
 //*****************************************************************************
 
-export function ImportView({doc, updateDoc, buffer, setBuffer}) {
+function ext2format(ext) {
+  switch(ext) {
+    case ".rtf": return "rtf"
+  }
+  return "text"
+}
+
+export function ImportView({updateDoc, buffer, setBuffer}) {
   const {file, ext, content} = buffer
 
   console.log("File:", file, "Ext:", ext)
 
-  switch(ext) {
-    case ".txt": return <ImportTXT doc={doc} updateDoc={updateDoc} content={content} setBuffer={setBuffer}/>
+  const [format, setFormat] = useState(ext2format(ext))
+  const [imported, setImported] = useState()
+
+  return <VBox style={{ overflow: "auto" }}>
+    <ImportBar format={format} setFormat={setFormat} imported={imported} updateDoc={updateDoc} buffer={buffer} setBuffer={setBuffer}/>
+    <HBox style={{ overflow: "auto" }}>
+      <VBox className="ImportSettings">
+        <SelectFormat format={format} content={content} setImported={setImported}/>
+      </VBox>
+      <Preview imported={imported}/>
+    </HBox>
+  </VBox>
+}
+
+function ImportBar({format, setFormat, imported, updateDoc, buffer, setBuffer}) {
+
+  function Import(e) {
+    setBuffer(undefined)
+
+    const story = maweFromTree({
+      elements: [{
+        type: "element", name: "story",
+        attributes: {
+          format: "mawe"
+        },
+        elements: [
+          {
+            type: "element", name: "body",
+            elements: imported,
+          }
+        ]
+    }]})
+    updateDoc(story)
   }
-  return null
+
+  function Cancel(e) {
+    setBuffer(undefined)
+  }
+
+  return <ToolBox>
+    <Label>Import: {buffer.file?.name ?? "Clipboard"}</Label>
+    <Separator/>
+    <SelectFormatButton value={format} setFormat={setFormat}/>
+    <Separator/>
+    <Button variant="contained" color="error" onClick={Cancel}>Cancel</Button>
+    <Separator/>
+    <Button variant="contained" color="success" onClick={Import}>Import</Button>
+    <Separator/>
+  </ToolBox>
+}
+
+class SelectFormat extends React.PureComponent {
+  render() {
+    const {format, content, setImported} = this.props
+
+    switch(format) {
+      case "text": return <ImportTXT content={content} setImported={setImported}/>
+    }
+    return null
+  }
+}
+
+class SelectFormatButton extends React.PureComponent {
+
+  static choices = {
+    "text": {name: "Text",},
+  }
+
+  static order = ["text"]
+
+  render() {
+    const {format, setFormat} = this.props;
+    //const type = node?.type ?? undefined
+
+    const choices = this.constructor.choices
+    const order   = this.constructor.order
+    const name    = format in choices ? choices[format].name : "Text"
+
+    //console.log("Block type:", type)
+
+    return <PopupState variant="popover" popupId="file-menu">
+      {(popupState) => <React.Fragment>
+        <Button tooltip="Paragraph style" style={{justifyContent: "flex-start"}} {...bindTrigger(popupState)}>Format: {name}</Button>
+        <Menu {...bindMenu(popupState)}>
+          {order.map(k => [k, choices[k]]).map(([k, v]) => (
+            <MenuItem key={k} value={k} onClick={e => {setFormat(k); popupState.close(e)}}>
+              {v.name}
+              </MenuItem>
+            )
+          )}
+          {/*
+          <ListSubheader>RTF</ListSubheader>
+          <MenuItem value="rtf1">RTF, A4, 1-side</MenuItem>
+          <MenuItem value="rtf2">RTF, A4, 2-side</MenuItem>
+          <ListSubheader>LaTeX</ListSubheader>
+          <MenuItem value="tex1">LaTeX, A5, 1-side</MenuItem>
+          <MenuItem value="tex2">LaTeX, A5 booklet</MenuItem>
+          <ListSubheader>Other</ListSubheader>
+          <MenuItem value="md">MD (Mark Down)</MenuItem>
+          */}
+        </Menu>
+      </React.Fragment>
+      }
+    </PopupState>
+  }
 }
 
 //*****************************************************************************
@@ -61,58 +168,64 @@ export function ImportView({doc, updateDoc, buffer, setBuffer}) {
 //
 //*****************************************************************************
 
-function ImportTXT({content, setBuffer, doc, updateDoc}) {
+class ImportTXT extends React.PureComponent {
 
-  const [linebreak, setLinebreak] = useState("\n\n")
+  constructor(props) {
+    super(props);
+    this.state = {
+      linebreak: "double"
+    };
+  }
 
-  const imported = importTXT(content, linebreak)
+  setLinebreak(linebreak) {
+    this.setState({linebreak})
+  }
 
-  return <HBox style={{ overflow: "auto" }}>
-    <VBox>
+  getLinebreak() {
+    switch(this.state.linebreak) {
+      case "single": return "\n"
+      default:
+      case "double": return "\n\n"
+    }
+  }
+
+  render() {
+    const {content, setImported} = this.props
+
+    setImported(importTXT(content, this.getLinebreak()))
+
+    return <>
       <Label>Text import</Label>
-    </VBox>
-    <Preview imported={imported}/>
-    <ImportIndex style={{ maxWidth: "300px", width: "300px" }}/>
-    </HBox>
+      <TextField select label="Line break" value={this.state.linebreak} onChange={e => this.setLinebreak(e.target.value)}>
+        <MenuItem value="double">Double</MenuItem>
+        <MenuItem value="single">Single</MenuItem>
+      </TextField>
+    </>
+  }
 }
 
 //-----------------------------------------------------------------------------
+
+export function text2lines(content, linebreak = "\n\n") {
+  return content
+    .replaceAll("\r", "")
+    .split(linebreak)
+    .map(line => line.replaceAll(/\s+/g, " ").trim())
+}
 
 function importTXT(content, linebreak) {
-  const paragraphs = content
-    .replaceAll("\r", "")
-    //.split(/\n+/)
-    .split(linebreak)
-    .map(line => line.replaceAll("\n", " "))
-    .map(line => line.trim())
-    .map(line => ({type: "p", text: line}))
+
+  const elements = text2lines(content, linebreak)
+    .map(line => ({
+      type: "element", name: "p", id: nanoid(),
+      elements: [{type: "text", text: line}]
+    }))
   ;
-  return paragraphs
-}
-
-//*****************************************************************************
-//
-// Import preview
-//
-//*****************************************************************************
-
-function ImportIndex() {
-  return null
-}
-
-//-----------------------------------------------------------------------------
-
-function Preview({imported}) {
-
-  return <div className="Filler Board">
-    <DeferredRender>
-      <div className="Sheet Regular">
-        {imported && imported.map(elem => <p>
-          {elem.text}
-          <span style={{marginLeft: "2pt", color: "grey"}}>&para;</span>
-          </p>
-      )}
-      </div>
-    </DeferredRender>
-  </div>
+  return [{
+    type: "element", name: "part", id: nanoid(),
+    elements: [{
+      type: "element", name: "scene", id: nanoid(),
+      elements
+    }]
+  }]
 }

--- a/src/gui/import/import.js
+++ b/src/gui/import/import.js
@@ -11,7 +11,7 @@ import "../common/styles/sheet.css"
 
 import React, {
   useMemo, useCallback,
-  useDeferredValue,
+  useState,
 } from 'react';
 
 import {
@@ -38,42 +38,63 @@ import {
   updateDocStoryType, updateDocChapterElem, updateDocChapterType,
 } from "../common/components";
 
-//-----------------------------------------------------------------------------
+//*****************************************************************************
+//
+// Import view
+//
+//*****************************************************************************
 
 export function ImportView({doc, updateDoc, buffer, setBuffer}) {
   const {file, ext, content} = buffer
 
   console.log("File:", file, "Ext:", ext)
 
-  const imported = importTXT(content)
+  switch(ext) {
+    case ".txt": return <ImportTXT doc={doc} updateDoc={updateDoc} content={content} setBuffer={setBuffer}/>
+  }
+  return null
+}
+
+//*****************************************************************************
+//
+// Text import
+//
+//*****************************************************************************
+
+function ImportTXT({content, setBuffer, doc, updateDoc}) {
+
+  const [linebreak, setLinebreak] = useState("\n\n")
+
+  const imported = importTXT(content, linebreak)
 
   return <HBox style={{ overflow: "auto" }}>
-    <ImportIndex style={{ maxWidth: "300px", width: "300px" }}/>
+    <VBox>
+      <Label>Text import</Label>
+    </VBox>
     <Preview imported={imported}/>
-    <ImportSettings doc={doc} updateDoc={updateDoc}/>
-  </HBox>
+    <ImportIndex style={{ maxWidth: "300px", width: "300px" }}/>
+    </HBox>
 }
 
 //-----------------------------------------------------------------------------
 
-function importTXT(content) {
+function importTXT(content, linebreak) {
   const paragraphs = content
     .replaceAll("\r", "")
     //.split(/\n+/)
-    .split(/\n/)
+    .split(linebreak)
+    .map(line => line.replaceAll("\n", " "))
     .map(line => line.trim())
     .map(line => ({type: "p", text: line}))
   ;
   return paragraphs
 }
 
-//-----------------------------------------------------------------------------
-
-function ImportSettings() {
-  return null
-}
-
-//-----------------------------------------------------------------------------
+//*****************************************************************************
+//
+// Import preview
+//
+//*****************************************************************************
 
 function ImportIndex() {
   return null
@@ -86,7 +107,7 @@ function Preview({imported}) {
   return <div className="Filler Board">
     <DeferredRender>
       <div className="Sheet Regular">
-        {imported.map(elem => <p>
+        {imported && imported.map(elem => <p>
           {elem.text}
           <span style={{marginLeft: "2pt", color: "grey"}}>&para;</span>
           </p>

--- a/src/gui/import/import.js
+++ b/src/gui/import/import.js
@@ -1,0 +1,49 @@
+//*****************************************************************************
+//*****************************************************************************
+//
+// File import view
+//
+//*****************************************************************************
+//*****************************************************************************
+
+//import "./styles/export.css"
+import "../common/styles/sheet.css"
+
+import React, {
+  useMemo, useCallback,
+  useDeferredValue,
+} from 'react';
+
+import {
+  FlexBox, VBox, HBox, Filler, VFiller, HFiller,
+  ToolBox, Button, Icon, Tooltip,
+  ToggleButton, ToggleButtonGroup,
+  Radio,
+  Input,
+  SearchBox,
+  Label,
+  List, ListItem, ListItemText, ListSubheader,
+  Grid,
+  Separator, Loading, addClass,
+  TextField, SelectFrom,
+  MenuItem,
+  Accordion, AccordionSummary, AccordionDetails,
+  DeferredRender,
+  Inform,
+} from "../common/factory";
+
+import { elemName, getSuffix, nanoid, filterCtrlElems } from "../../document/util";
+import {
+  EditHead, SectionWordInfo,
+  updateDocStoryType, updateDocChapterElem, updateDocChapterType,
+} from "../common/components";
+
+//-----------------------------------------------------------------------------
+
+export function ImportView({doc, updateDoc, buffer, setBuffer}) {
+  const {file, content} = buffer
+
+  console.log("File:", file)
+
+  return null;
+}

--- a/src/gui/import/import.js
+++ b/src/gui/import/import.js
@@ -45,5 +45,53 @@ export function ImportView({doc, updateDoc, buffer, setBuffer}) {
 
   console.log("File:", file, "Ext:", ext)
 
-  return null;
+  const imported = importTXT(content)
+
+  return <HBox style={{ overflow: "auto" }}>
+    <ImportIndex style={{ maxWidth: "300px", width: "300px" }}/>
+    <Preview imported={imported}/>
+    <ImportSettings doc={doc} updateDoc={updateDoc}/>
+  </HBox>
+}
+
+//-----------------------------------------------------------------------------
+
+function importTXT(content) {
+  const paragraphs = content
+    .replaceAll("\r", "")
+    //.split(/\n+/)
+    .split(/\n/)
+    .map(line => line.trim())
+    .map(line => ({type: "p", text: line}))
+  ;
+  return paragraphs
+}
+
+//-----------------------------------------------------------------------------
+
+function ImportSettings() {
+  return null
+}
+
+//-----------------------------------------------------------------------------
+
+function ImportIndex() {
+  return null
+}
+
+//-----------------------------------------------------------------------------
+
+function Preview({imported}) {
+
+  return <div className="Filler Board">
+    <DeferredRender>
+      <div className="Sheet Regular">
+        {imported.map(elem => <p>
+          {elem.text}
+          <span style={{marginLeft: "2pt", color: "grey"}}>&para;</span>
+          </p>
+      )}
+      </div>
+    </DeferredRender>
+  </div>
 }

--- a/src/gui/import/import.js
+++ b/src/gui/import/import.js
@@ -41,9 +41,9 @@ import {
 //-----------------------------------------------------------------------------
 
 export function ImportView({doc, updateDoc, buffer, setBuffer}) {
-  const {file, content} = buffer
+  const {file, ext, content} = buffer
 
-  console.log("File:", file)
+  console.log("File:", file, "Ext:", ext)
 
   return null;
 }

--- a/src/gui/import/preview.js
+++ b/src/gui/import/preview.js
@@ -1,0 +1,50 @@
+//*****************************************************************************
+//
+// Import preview
+//
+//*****************************************************************************
+
+import React from "react"
+import { DeferredRender } from "../common/factory"
+
+//-----------------------------------------------------------------------------
+
+export class Preview extends React.PureComponent {
+  render() {
+    const {imported} = this.props
+
+    if(!imported) return null
+
+    return <>
+      <ImportIndex style={{ maxWidth: "300px", width: "300px" }} imported={imported}/>
+      <div className="Filler Board">
+        <div className="Sheet Regular">
+          <DeferredRender>{imported.map(PreviewPart)}</DeferredRender>
+          </div>
+      </div>
+    </>
+  }
+}
+
+function PreviewPart(part) {
+  return <div key={part.id}>
+    {part.elements.map(PreviewScene)}
+  </div>
+}
+
+function PreviewScene(scene) {
+  return <div key={scene.id}>
+    {scene.elements.map(PreviewParagraph)}
+  </div>
+}
+
+function PreviewParagraph(p) {
+  return <p key={p.id}>
+    {p.elements.map(n => n.text).join(" ")}
+    <span style={{marginLeft: "2pt", color: "grey"}}>&para;</span>
+  </p>
+}
+
+function ImportIndex({imported}) {
+  return null
+}

--- a/src/gui/import/styles/import.css
+++ b/src/gui/import/styles/import.css
@@ -1,0 +1,8 @@
+.ImportSettings {
+  min-width: 200px;
+  padding: 6px;
+  border-right: 1px solid lightgray;
+/*
+  background: white;
+*/
+}


### PR DESCRIPTION
Create import view, which can be used to preview file imports. Later, we could use this also for importing content from clipboard (at least text, just to control paragraph breaks).

First we implement text (possibly MD also) file imports. The options we like to have is how the paragraphs are separated:

- Single newline
- Double newline
- Something else

Resolves #35 
Resolves #120 
