### PR TITLE
fix: upgrade electron to patched version (CVE-2026-70608)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.2.0",
-        "electron": "^40.10.6",
+        "electron": "^43.0.0",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "node": "^24.19.0"
@@ -3118,10 +3118,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
-      "hasInstallScript": true,
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.0.0.tgz",
+      "integrity": "sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -3129,7 +3128,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.2.0",
-        "electron": "^43.0.0",
+        "electron": "^41.10.3",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "node": "^24.19.0"
@@ -3118,9 +3118,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.0.0.tgz",
-      "integrity": "sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==",
+      "version": "41.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -3128,8 +3129,7 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js",
-        "install-electron": "install.js"
+        "electron": "cli.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.2.0",
-    "electron": "^40.10.6",
+    "electron": "^43.0.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "node": "^24.19.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.2.0",
-    "electron": "^43.0.0",
+    "electron": "^41.10.3",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "node": "^24.19.0"
@@ -67,7 +67,7 @@
     }
   },
   "allowScripts": {
-    "electron@40.10.6": true,
+    "electron@41.10.3": true,
     "electron-winstaller@5.4.0": true,
     "esbuild@0.25.12": true,
     "esbuild@0.28.1": true,


### PR DESCRIPTION
## Summary
Upgrade electron from `40.10.6` to `41.10.3` to fix CVE-2026-70608.

(Previous revision of this PR targeted `43.0.0`; narrowed after review to the minimum patched release — see discussion below.)

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-70608 |
| **Severity** | HIGH (CVSS 7.2) |
| **Description** | Sandboxed iframe can bypass the `allow-popups` restriction via the OpenURL navigation path |
| **Fixed in** | 39.8.10, 41.10.3, 42.0.1 (no patched 40.x release exists) |

## Scope
`package.json` / `package-lock.json` only. No application source changes.

## Node requirement
Unchanged. `electron@41.10.3` requires `Node >= 22.12.0`, identical to the currently pinned `electron@40.10.6`. This PR does not raise the project's Node requirement.

## Exploitability
`mawejs` does not embed untrusted content in sandboxed iframes and does not use `window.open`, `setWindowOpenHandler`, or `shell.openExternal` anywhere in `src/` or `electron/` (the single `BrowserWindow` only loads the app's own dev-server URL or local `renderer/index.html`). Per the advisory, apps that don't embed untrusted content in sandboxed iframes are not affected — so this is a hardening upgrade rather than a fix for an active exploit path in this app today.

## Validation
- `npm test` — passes
- `npm run build:vite` — passes
- `npm run build` (electron-builder package build) — passes

## Follow-up
The broader Electron 43 / Node modernization is intentionally left out of scope here and can be tracked as a separate PR.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com), narrowed in scope per maintainer review feedback.*

<!-- orbis-meta: rule=CVE-2026-70608 scanner=trivy vuln=CVE-2026-70608 -->